### PR TITLE
dump_all: drop the unused OTP read (faults on hardware)

### DIFF
--- a/tcl/as11.cfg
+++ b/tcl/as11.cfg
@@ -114,7 +114,6 @@ proc dump_all {} {
 	dump_section as11_tamp.bin         0x58004400 0x400
 	dump_section as11_dbgmcu.bin       0x5C001000 0x100
 	dump_section as11_sysmem.bin       0x1FF00000 0x20000
-	dump_section as11_otp.bin          0x08FFF000 0x400
 
 	dump_dtcm     as11_dtcm.bin
 	dump_axi_sram as11_axi_sram.bin


### PR DESCRIPTION
`dump_all` reads the STM32 OTP at `0x08FFF000`. That area isn't used on Air11, and on this H7 reading never-written flash raises an ECC double-error (bus fault) that aborts `dump_all` half-way — before the RAM sections. This drops the OTP read from `dump_all`.

(Per review: removing the OTP read rather than wrapping every `dump_section` in `catch`, so an incomplete `dump` / `as11.bin` can't be silently hidden.)
