### PR TITLE
as11 keys: tolerate reset-halt failures

### DIFF
--- a/tcl/as11-keys.tcl
+++ b/tcl/as11-keys.tcl
@@ -200,7 +200,11 @@ namespace eval as11_keys {
         set addr [_key_offset $idx]
 
         set status [catch {
-            reset halt
+            # Prefer a reset-halt for a clean state; fall back to a plain halt
+            # if reset-halt does not land (observed on secure boot / some debuggers).
+            catch {reset halt}
+            set _t [target current]
+            if {[$_t curstate] ne "halted"} { halt }
             if {[llength [info commands freeze_iwdg]] != 0} {
                 catch {freeze_iwdg}
             }
@@ -221,7 +225,7 @@ namespace eval as11_keys {
 
         catch {reset run}
         if {$status != 0} {
-            return -options $opts $result
+            error $result
         }
         return ""
     }


### PR DESCRIPTION
Make as11_keys::key fall back to a plain halt when reset-halt does not leave the target halted, and avoid Jim Tcl's unsupported return -options form on errors.

Keep reset-run cleanup after the key read.

Based-on: m-kozlowski/airbreak-plus#28